### PR TITLE
Create new directory if specified nonexistent directory as a part of --output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ List up GitHub user / org repositories filtered by topics
   - JSON
   - Markdown
 - Output the results to stdout or file
+  - Specify 'ghc/result.md' as output filename and if 'ghc' does not exist, create new directory
 
 ## Installtion
 

--- a/ghc/cli.py
+++ b/ghc/cli.py
@@ -68,7 +68,7 @@ def setup_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '-o', '--output',
         dest='filename',
-        help='Filename to output the results. Output stdout if not specified'
+        help='Filename to save the results. Output to stdout if not specified'
     )
 
     parser.add_argument(

--- a/ghc/stream.py
+++ b/ghc/stream.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from dataclasses import dataclass, field
 from typing import IO, Optional, Union
@@ -29,6 +30,14 @@ class FileHandler(StreamHandler):
     newline: Optional[str] = None
 
     stream: Optional[IO[str]] = field(init=False, default=None)  # type: ignore
+
+    def __post_init__(self) -> None:
+        self.mkdir()
+
+    def mkdir(self) -> None:
+        fp = self.filename.split('/')
+        if len(fp) > 1:
+            os.makedirs('/'.join(fp[:-1]), mode=0o755, exist_ok=True)
 
     def _open(self) -> IO[str]:
         if self.stream is None:

--- a/tests/unit/test_stream.py
+++ b/tests/unit/test_stream.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+
+from ghc.stream import FileHandler
+
+
+class TestFileHandler:
+    @pytest.fixture(params=['test.md', 'new/test.md'])
+    def filename(self, request):
+        filename = request.param
+        yield filename
+        Path(filename).unlink()
+
+    def test_file_handler(self, filename: str):
+        msg = 'hello world'
+
+        with FileHandler(filename=filename) as fd:
+            fd.write(msg)
+
+        assert Path(filename).exists() is True
+
+        with open(filename) as fd:
+            actual_msg = fd.read().replace('\n', '')
+
+        assert actual_msg == msg


### PR DESCRIPTION
## Related Issue
<!-- close #{issue_number} -->

close #

## Why need ?

If specify nonexistent directory as a part of --output option, we get FileNotFoundError exception.

## ToDo

- [x] Create new directory if specified nonexistent directory as a part of --output option
- [ ] Add unit test
